### PR TITLE
Update Private Open VSCode Example to one render.yaml

### DIFF
--- a/Dockerfile.oauth2-proxy
+++ b/Dockerfile.oauth2-proxy
@@ -7,4 +7,8 @@ USER root
 
 RUN apk --no-cache add curl
 
+ARG OPENVSCODE_HOSTPORT
+
+ENV OAUTH2_PROXY_UPSTREAMS="http://${OPENVSCODE_HOSTPORT}"
+
 ENTRYPOINT ["/bin/oauth2-proxy", "--config=./oauth2-proxy.cfg"]

--- a/Dockerfile.oauth2-proxy
+++ b/Dockerfile.oauth2-proxy
@@ -1,0 +1,10 @@
+
+FROM quay.io/oauth2-proxy/oauth2-proxy
+
+COPY oauth2-proxy.cfg .
+
+USER root
+
+RUN apk --no-cache add curl
+
+ENTRYPOINT ["/bin/oauth2-proxy", "--config=./oauth2-proxy.cfg"]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Gitpod's OpenVSCode Server + Oauth2 Proxy
 Deploy Gitpod's VSCode Webserver and Oauth2 Proxy on Render. 
 
-The VSCode will be a private service and only be accessed by a proxy with oauth2 authentication. 
+The VSCode instance will be a private service and can only be accessed by a proxy with oauth2 authentication. 
 
 [![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy)
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,7 @@
-# Gitpod's OpenVSCode Server
-Deploy Gitpod's VSCode Webserver on Render
+# Gitpod's OpenVSCode Server + Oauth2 Proxy
+Deploy Gitpod's VSCode Webserver and Oauth2 Proxy on Render 
+The VSCode will be a private service and only be accessed by a proxy with oauth2 authentication 
 
 [![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy)
 
 
-Manual deploy:
-- [Connect your GitHub account to your Render account](https://render.com/docs/github).
-- Clone this repo.
-- Create a new web service using this repo and the following parameters:
-  - Environment: Docker
-  - Advanced > Add Environment Variable
-    - key: SERVER_VERSION 
-    - value: v1.59.0
-  - Advanced > Add Disk
-    - Name: data
-    - Mount Path: /home/workspace
-- Watch your VSCode Webserver deploy, and then log in at the public URL listed below your web service name.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Gitpod's OpenVSCode Server + Oauth2 Proxy
-Deploy Gitpod's VSCode Webserver and Oauth2 Proxy on Render 
-The VSCode will be a private service and only be accessed by a proxy with oauth2 authentication 
+Deploy Gitpod's VSCode Webserver and Oauth2 Proxy on Render. 
+
+The VSCode will be a private service and only be accessed by a proxy with oauth2 authentication. 
 
 [![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy)
 

--- a/oauth2-proxy.cfg
+++ b/oauth2-proxy.cfg
@@ -1,0 +1,96 @@
+## OAuth2 Proxy Config File
+## https://github.com/oauth2-proxy/oauth2-proxy
+
+## <addr>:<port> to listen on for HTTP/HTTPS clients
+http_address = "0.0.0.0:4180"
+# https_address = "0.0.0.0:443"
+
+## Are we running behind a reverse proxy? Will not accept headers like X-Real-Ip unless this is set.
+reverse_proxy = true
+
+## TLS Settings
+# tls_cert_file = ""
+# tls_key_file = ""
+
+## the OAuth Redirect URL.
+# defaults to the "https://" + requested host header + "/oauth2/callback"
+# redirect_url = "https://openvscode-secure-server.onrender.com/oauth2/callback"
+
+## the http url(s) of the upstream endpoint. If multiple, routing is based on path
+# upstreams = []
+
+## Logging configuration
+#logging_filename = ""
+#logging_max_size = 100
+#logging_max_age = 7
+#logging_local_time = true
+#logging_compress = false
+#standard_logging = true
+#standard_logging_format = "[{{.Timestamp}}] [{{.File}}] {{.Message}}"
+#request_logging = true
+#request_logging_format = "{{.Client}} - {{.Username}} [{{.Timestamp}}] {{.Host}} {{.RequestMethod}} {{.Upstream}} {{.RequestURI}} {{.Protocol}} {{.UserAgent}} {{.StatusCode}} {{.ResponseSize}} {{.RequestDuration}}"
+#auth_logging = true
+#auth_logging_format = "{{.Client}} - {{.Username}} [{{.Timestamp}}] [{{.Status}}] {{.Message}}"
+
+## pass HTTP Basic Auth, X-Forwarded-User and X-Forwarded-Email information to upstream
+# pass_basic_auth = true
+# pass_user_headers = true
+## pass the request Host Header to upstream
+## when disabled the upstream Host is used as the Host Header
+# pass_host_header = true
+
+## Email Domains to allow authentication for (this authorizes any email on this domain)
+## for more granular authorization use `authenticated_emails_file`
+## To authorize any email addresses use "*"
+email_domains = "*"
+
+## The OAuth Provider, Client ID, Secret
+# provider = "google"
+# client_id = 
+# client_secret = 
+
+## Pass OAuth Access token to upstream via "X-Forwarded-Access-Token"
+# pass_access_token = false
+
+## Authenticated Email Addresses File (one email per line)
+# authenticated_emails_file = ""
+
+## Htpasswd File (optional)
+## Additionally authenticate against a htpasswd file. Entries must be created with "htpasswd -B" for bcrypt encryption
+## enabling exposes a username/login signin form
+# htpasswd_file = ""
+
+## bypass authentication for requests that match the method & path. Format: method=path_regex OR path_regex alone for all methods
+# skip_auth_routes = [
+#   "GET=^/probe",
+#   "^/metrics"
+# ]
+
+## Templates
+## optional directory with custom sign_in.html and error.html
+# custom_templates_dir = ""
+
+## skip SSL checking for HTTPS requests
+# ssl_insecure_skip_verify = false
+
+
+## Cookie Settings
+## Name     - the cookie name
+## Secret   - the seed string for secure cookies; should be 16, 24, or 32 bytes
+##            for use with an AES cipher when cookie_refresh or pass_access_token
+##            is set
+## Domain   - (optional) cookie domain to force cookies to (ie: .yourcompany.com)
+## Expire   - (duration) expire timeframe for cookie
+## Refresh  - (duration) refresh the cookie when duration has elapsed after cookie was initially set.
+##            Should be less than cookie_expire; set to 0 to disable.
+##            On refresh, OAuth token is re-validated.
+##            (ie: 1h means tokens are refreshed on request 1hr+ after it was set)
+## Secure   - secure cookies are only sent by the browser of a HTTPS connection (recommended)
+## HttpOnly - httponly cookies are not readable by javascript (recommended)
+cookie_name = "_oauth2_proxy"
+cookie_secret = "rgDCTsI7LFUVT1AA3aK3kQ=="
+# cookie_domains = ""
+cookie_expire = "24h"
+cookie_refresh = "2h"
+cookie_secure = true
+# cookie_httponly = true

--- a/render.yaml
+++ b/render.yaml
@@ -1,9 +1,25 @@
 services:
 - type: pserv
-  name: gitpod-openvscode-server-example
+  name: openvscode-server
   env: docker
-  repo: https://github.com/render-examples/gitpod-openvscode-server-example.git
   disk:
     name: data
     mountPath: /home/workspace
     sizeGB: 1
+- type: web
+  name: oauth2-proxy
+  env: docker
+  dockerfilePath: Dockerfile.oauth2-proxy  
+  envVars:
+    - key: OPENVSCODE_HOSTPORT
+      fromService:
+        name: openvscode-server
+        type: pserv
+        property: hostport 
+  # Use placeholders for sensitive data to allow Client information to be entered securely in the Render dashboard
+    - key: OAUTH2_PROXY_CLIENT_ID
+      sync: false
+    - key: OAUTH2_PROXY_CLIENT_SECRET
+      sync: false
+    - key: OAUTH2_PROXY_PROVIDER
+      sync: false


### PR DESCRIPTION
This PR creates one example project which combines the OpenVSCode Server examples and OAuth2-Proxy examples into one stack easily deployable with one render.yaml file.