### PR TITLE
Sets autoDeploy to false

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -2,6 +2,7 @@ services:
 - type: pserv
   name: openvscode-server
   env: docker
+  autoDeploy: false
   disk:
     name: data
     mountPath: /home/workspace
@@ -10,6 +11,7 @@ services:
   name: oauth2-proxy
   env: docker
   dockerfilePath: Dockerfile.oauth2-proxy  
+  autoDeploy: false
   envVars:
     - key: OPENVSCODE_HOSTPORT
       fromService:


### PR DESCRIPTION
By setting `autoDeploy: false` in the the `render.yaml`, we can ensure that subsequent merges to the main branch of this repository will not trigger deploys for any instances that have been created and deployed by the Deploy to Render button.

However, merging this PR will trigger a final forced deployment of any instances created and deployed by the Deploy to Render button.

See [the Render docs](https://render.com/docs/deploy-to-render) for more information.

Signed-off-by: zach wick <zach@render.com>